### PR TITLE
allowing VMs to be imported without osProfile property

### DIFF
--- a/internal/services/compute/virtual_machine_import.go
+++ b/internal/services/compute/virtual_machine_import.go
@@ -46,9 +46,9 @@ func importVirtualMachine(osType compute.OperatingSystemTypes, resourceType stri
 		}
 
 		// we don't support VM's without an OS Profile / attach
-		if vm.VirtualMachineProperties.OsProfile == nil {
-			return []*pluginsdk.ResourceData{}, fmt.Errorf("The %q resource doesn't support attaching OS Disks - please use the `azurerm_virtual_machine` resource instead", resourceType)
-		}
+		//if vm.VirtualMachineProperties.OsProfile == nil {
+		//	return []*pluginsdk.ResourceData{}, fmt.Errorf("The %q resource doesn't support attaching OS Disks - please use the `azurerm_virtual_machine` resource instead", resourceType)
+		//}
 
 		hasSshKeys := false
 		if osType == compute.OperatingSystemTypesLinux {


### PR DESCRIPTION
sample code to allow imports of VMs that are restored and do not expose osProfile property in ARM.
Needs to be thoroughly tested. 